### PR TITLE
feat(i18n): add greek

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The configuration that can be found in `src/configs/app.js` comes with many conf
     * Cards: Commands displayed in a card view instead of a long list.
     * Compact: A list with reduced paddings to preserve space, as well as redacted permissions and description preview, to only display the command name.
 * `locale` - The language all static text should be in, using ISO 639-1 language codes (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) **Note: Locales must be added manually before building the application. See below for more information.**
+    * `el` (greek)
     * `en` (english) **default**
     * `et` (estonian)
     * `fr` (french)

--- a/src/data/locales/el.json
+++ b/src/data/locales/el.json
@@ -1,0 +1,14 @@
+{
+    "categories": "Κατηγορίες",
+    "commands": "Εντολές",
+    "search_placeholder": "Αναζήτησε με βάση την εντολή ή την περιγραφή...",
+    "permissions": "Άδειες",
+    "menu_link_more": "Περισσότερα",
+    "footer_copyright_domain": "© {{domain}} – Με επιφύλαξη κάθε νόμιμου δικαιώματος.",
+    "footer_copyright_disclaimer": "Δεν είμαστε συσχετισμένοι, εξουσιοδοτημένοι, εγκεκριμένοι από, ή με οποιοδήποτε τρόπο επίσημα συνδεδεμένοι με την Discord LTD., ή με κάποια από τις θυγατρικές εταιρείες της ή τους συνεργάτες της.",
+    "command_view_return": "Eπίστρεψε στην λίστα εντολών",
+    "command_view_bot_default_prefix": "Το προκαθορισμένο πρόθεμα του bot",
+    "command_view_arguments": "Επιχειρήματα",
+    "command_view_usage": "Χρήση",
+    "command_view_argument_required": "απαιτείται"
+}

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -1,5 +1,6 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
+import localeEL from "../data/locales/el.json";
 import localeEN from "../data/locales/en.json";
 import localeET from "../data/locales/et.json";
 import localeFR from "../data/locales/fr.json";
@@ -10,6 +11,9 @@ import localeTR from "../data/locales/tr.json";
 import appConfig from "../configs/app";
 
 const resources = {
+    el: {
+        translation: localeEL
+    },
     en: {
         translation: localeEN
     },


### PR DESCRIPTION
This PR adds Greek translation.

Unfortunately, the ISO Greek language code is `el` which alphabetically is higher(?) compared to `en`.
Let me know if I should re-order it at the bottom in the README and/or in i18n.js.
