### PR TITLE
fix(Search): Keep original category names in search instead of using URL optimised variables

### DIFF
--- a/src/components/commands/List.js
+++ b/src/components/commands/List.js
@@ -3,10 +3,10 @@ import Link from "next/link";
 import Search from "./Search";
 import styles from "./_commands.module.sass";
 
-export default function List({ commands, mode, colors, isCategoryActive, currentCategory, onSearch, t }) {
+export default function List({ commands, mode, colors, isCategoryActive, onSearch, t }) {
     return (
         <div className={`${styles.commands} ${styles["commands--" + mode]}`}>
-            <Search onSearch={onSearch} isCategoryActive={isCategoryActive} currentCategory={isCategoryActive ? commands[0].category : undefined} t={t} />
+            <Search onSearch={onSearch} isCategoryActive={isCategoryActive} currentCategory={isCategoryActive ? commands[0].category : null} t={t} />
 
             {commands.map((command, i) => (
                 <Link href={command.url.full} shallow={true} key={i}>

--- a/src/components/commands/List.js
+++ b/src/components/commands/List.js
@@ -6,7 +6,7 @@ import styles from "./_commands.module.sass";
 export default function List({ commands, mode, colors, isCategoryActive, currentCategory, onSearch, t }) {
     return (
         <div className={`${styles.commands} ${styles["commands--" + mode]}`}>
-            <Search onSearch={onSearch} isCategoryActive={isCategoryActive} currentCategory={currentCategory} t={t} />
+            <Search onSearch={onSearch} isCategoryActive={isCategoryActive} currentCategory={isCategoryActive ? commands[0].category : undefined} t={t} />
 
             {commands.map((command, i) => (
                 <Link href={command.url.full} shallow={true} key={i}>

--- a/src/components/commands/Search.js
+++ b/src/components/commands/Search.js
@@ -19,7 +19,7 @@ export default function Search({ onSearch, isCategoryActive, currentCategory, t 
     return (
         <div className={`${styles["commands__search"]} ${isCategoryActive ? styles["commands__search--isCategory"] : null}`} onKeyDown={(input) => onSearch(input.target.value)}>
             <div className={styles["commands__search-icon"]}><FiSearch /></div>
-            {currentCategory ? <div className={styles.currentCategory} ref={categoryTagRef}>{currentCategory.substr(1)}</div> : null}
+            {currentCategory ? <div className={styles.currentCategory} ref={categoryTagRef}>{currentCategory}</div> : null}
 
             <input type="text" className={styles["commands__search-input"]} style={{"paddingLeft": currentCategory ? (dimensions.width + 30 + "px") : "1em"}} placeholder={t("search_placeholder")} />
         </div>

--- a/src/components/commands/_commands.module.sass
+++ b/src/components/commands/_commands.module.sass
@@ -31,7 +31,6 @@
                 color: $commands-search-marker-text-color
                 font-weight: bold
                 margin: 1em
-                text-transform: capitalize
                 padding: 0 0.5em
                 @include borderRadius($commands-search-marker-border-radius)
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -57,7 +57,6 @@ export default function Index({ categoryFilter = null }) {
                 mode={settings.listMode}
                 colors={settings.categoryColors}
                 isCategoryActive={typeof router.asPath.split("/category")[1] !== "undefined"}
-                currentCategory={router.asPath.split("/category")[1]}
                 onSearch={onSearch}
                 t={settings.t}
             />


### PR DESCRIPTION
This PR fixes the capitalisation in the search input.

`currentCategory` argument is now unused `components/commands/List.js#L6` with this fix, I can remove it if this won't be used anymore in the future.
https://github.com/Yimura/BotDocs/blob/f5751fc68a2469ca8e878ef0af8ae08417b12144/src/components/commands/List.js#L6